### PR TITLE
Update docker actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,4 +85,4 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ${{ env.DOCKER_TAGS }
+          tags: ${{ env.DOCKER_TAGS }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,10 +59,10 @@ jobs:
 
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -82,7 +82,7 @@ jobs:
           echo Docker Image tags: ${DOCKER_TAGS}
 
       - name: Build and Push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ${{ env.DOCKER_TAGS }}
+          tags: ${{ env.DOCKER_TAGS }


### PR DESCRIPTION
Docker build (on `main`) is currently failed to login error, which might be caused by the outdated docker actions version. This PR updated all the docker actions in GHA `CI.yml` to the latest versions with the hope to fix the docker build issue. 


<img width="494" alt="Screenshot 2023-12-04 at 09 52 06" src="https://github.com/GOMC-WSU/MoSDeF-dihedral-fit/assets/43968221/4c4421c3-c40e-447d-a4e4-5d008578891a">
