### PR TITLE
added links to examples for 4 more FFs to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ $$+ K_1 * (1 + cos(n_1*\theta - 180^o)) + K_2 * (1 + cos(n_2*\theta))$$
 $$+  K_3 * (1 + cos(n_3*\theta - 180^o)) +  K_4 * (1 + cos(n_4*\theta))$$
 
 ## Examples
-Some basic workflows that use this package</br>
+Some basic workflows that use this package and cover several force field (FF) types are [here](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit).  A summary of the FFs covered in the examples are listed below.
 
- - [OPLS-AA ethane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_1_opls_aa_ethane)</br>
- - [OPLS-AA propanoic acid dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_2_opls_aa_propionic_acid)</br>
- - [AMBER-AA butane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_3_amber_aa_butane)</br>
- - [TraPPE-UA butane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_4_trappe_ua_butane)</br>
- - [Mie-UA butane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_5_mie_ua_butane)</br>
- - [Exp6-AA butane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_6_exp6_aa_butane)</br>
+ - <b>OPLS-AA</b>: ethane dihedral
+ - <b>OPLS-AA</b>: propanoic acid dihedral
+ - <b>AMBER-AA</b>: butane dihedral
+ - <b>TraPPE-UA</b>: butane dihedral
+ - <b>Mie-UA</b>: butane dihedral
+ - <b>Exp6-AA</b>: butane dihedral
 
 ## Resources
 This package is made as an API with [MoSDeF](https://github.com/mosdef-hub) and [MoSDeF-GOMC](https://github.com/GOMC-WSU/MoSDeF-GOMC). For `mosdef_dihedral_fit` to function, the forcefield files must be in a supported MoSDeF format (preferably the GMSO force field format), and use MoSDeF-GOMC and GOMC to perform the simulation setup and simulations.

--- a/README.md
+++ b/README.md
@@ -81,8 +81,12 @@ $$+  K_3 * (1 + cos(n_3*\theta - 180^o)) +  K_4 * (1 + cos(n_4*\theta))$$
 ## Examples
 Some basic workflows that use this package</br>
 
- - [ethane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/ethane_HC_CT_CT_HC)</br>
- - [propanoic acid dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/protonated_fragment_CT_CT_C_OH)</br>
+ - [OPLS-AA ethane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_1_opls_aa_ethane)</br>
+ - [OPLS-AA propanoic acid dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_2_opls_aa_propionic_acid)</br>
+ - [AMBER-AA butane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_3_amber_aa_butane)</br>
+ - [TraPPE-UA butane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_4_trappe_ua_butane)</br>
+ - [Mie-UA butane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_5_mie_ua_butane)</br>
+ - [Exp6-AA butane dihedral](https://github.com/GOMC-WSU/GOMC_Examples/tree/main/MoSDeF-dihedral-fit/example_6_exp6_aa_butane)</br>
 
 ## Resources
 This package is made as an API with [MoSDeF](https://github.com/mosdef-hub) and [MoSDeF-GOMC](https://github.com/GOMC-WSU/MoSDeF-GOMC). For `mosdef_dihedral_fit` to function, the forcefield files must be in a supported MoSDeF format (preferably the GMSO force field format), and use MoSDeF-GOMC and GOMC to perform the simulation setup and simulations.


### PR DESCRIPTION
In the README file, I added a link to all the examples and added 4 new examples, covering more FFs.  The FF example added are as follows:

 - AMBER-AA=: butane dihedral
 - TraPPE-UA=: butane dihedral
 - Mie-UA=: butane dihedral
 - Exp6-AA=: butane dihedral