### PR TITLE
bug fix - randomly outputing misordered coord files

### DIFF
--- a/mosdef_dihedral_fit/dihedral_fit/fit_dihedral_with_gomc.py
+++ b/mosdef_dihedral_fit/dihedral_fit/fit_dihedral_with_gomc.py
@@ -802,8 +802,8 @@ def fit_dihedral_with_gomc(
 
     # Build the methanol liquid box_1
 
-    # liquid_box_0_length_nm must be a value <= 999.8 nm and an interger value in angstroms <= 9998 Ang
-    liquid_box_0_length_nm = 999.8
+    # liquid_box_0_length_nm must be a value <= 99.8 nm and an interger value in angstroms <= 998 Ang
+    liquid_box_0_length_nm = 99.8
 
     # Started building the fragment for the GOMC simulation with dihedral k values = 0
     box_0_liq = mb.fill_box(
@@ -903,7 +903,7 @@ def fit_dihedral_with_gomc(
     total_qm_scans = len(gaussian_raw_degrees_list)
 
     mdf_frw.write_xyz_file_from_gaussian_coordinates(
-        elementpdb_names_list,
+        atom_pdb_names_list,
         qm_parital_coordinate_file_starting_dir_and_name,
         qm_coordinate_file_extension,
         xyz_xsc_coor_files_directory,

--- a/mosdef_dihedral_fit/utils/file_read_and_write.py
+++ b/mosdef_dihedral_fit/utils/file_read_and_write.py
@@ -182,6 +182,9 @@ def write_xyz_file_from_gaussian_coordinates(
     atom_names_with_2_spaces_in_front = []
     for j_iter in range(0, len(atom_names_list)):
         atom_names_with_2_spaces_in_front.append(f"  {atom_names_list[j_iter]}")
+        print(f"******************")
+        print(f"  {atom_names_list[j_iter]}")
+        print(f"******************")
 
     for i_iter in range(1, total_qm_scans + 1):
         read_gausian_file_dir_name = f"{qm_parital_coordinate_file_starting_dir_and_name}{i_iter}.{qm_coordinate_file_extension}"

--- a/mosdef_dihedral_fit/utils/file_read_and_write.py
+++ b/mosdef_dihedral_fit/utils/file_read_and_write.py
@@ -182,9 +182,6 @@ def write_xyz_file_from_gaussian_coordinates(
     atom_names_with_2_spaces_in_front = []
     for j_iter in range(0, len(atom_names_list)):
         atom_names_with_2_spaces_in_front.append(f"  {atom_names_list[j_iter]}")
-        print(f"******************")
-        print(f"  {atom_names_list[j_iter]}")
-        print(f"******************")
 
     for i_iter in range(1, total_qm_scans + 1):
         read_gausian_file_dir_name = f"{qm_parital_coordinate_file_starting_dir_and_name}{i_iter}.{qm_coordinate_file_extension}"


### PR DESCRIPTION
bug fix - randomly outputing misordered coord files because elements names not atom names used in the xyz files that were used to create the coor file.