### PR TITLE
Need to lock GSD at gsd =3.3.2 until it is compatible (and others) with NumPy=>2.x

### DIFF
--- a/docs/environment_docs.yml
+++ b/docs/environment_docs.yml
@@ -18,6 +18,7 @@ dependencies:
   - mosdef-gomc>=1.4.0
   - pre-commit
   - sphinx=6.1.1
+  - gsd=3.3.2
   - pip
   - pip:
       - bump2version

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - mosdef-gomc>=1.4.0
   - pre-commit
   - sphinx=6.1.1
+  - gsd=3.3.2
   - pip
   - pip:
       - bump2version


### PR DESCRIPTION
Need to lock GSD at gsd =3.3.2 until it is compatible (and others) with NumPy=>2.x
