### PR TITLE
locking to mosdef-gomc 1.4.0 until Mosdef-gomc to update to Numpy>=2.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.12,<3.14
+  - python>=3.10,<3.12
   - vmd-python
   - ipython
   - numpydoc

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.10,<3.12
+  - python>=3.12,<3.14
   - vmd-python
   - ipython
   - numpydoc
@@ -15,7 +15,7 @@ dependencies:
   - pytest
   - pytest-cov
   - coverage
-  - mosdef-gomc>=1.4.0
+  - mosdef-gomc=1.4.0
   - pre-commit
   - sphinx=6.1.1
   - pip


### PR DESCRIPTION
locking to mosdef-gomc 1.4.0:

    until Mosdef-gomc to update to Numpy>=2.3, as vmd-python versions only cover numpy<2 or numpy>2.3
    mosedef currently covers numpy>=2,<2.3
